### PR TITLE
⬆️ Upgrade PHP 8.1 → 8.3

### DIFF
--- a/.docker/php.dockerfile
+++ b/.docker/php.dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm-alpine
+FROM php:8.3-fpm-alpine
 
 ARG UID
 ARG GID


### PR DESCRIPTION
Upgrade PHP from 8.1 to 8.3 in the php.dockerfile.

PHP 8.1 reached end of security support in November 2024.

Co-Authored-By: Oz <oz-agent@warp.dev>