### PR TITLE
🔧 Modernize docker-compose: Mailpit, MariaDB 11.4, Node 22

### DIFF
--- a/docker-compose.root.yml
+++ b/docker-compose.root.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 networks:
   laravel:
 
@@ -21,12 +19,12 @@ services:
       - redis
       - mysql
       - phpmyadmin
-      - mailhog
+      - mailpit
     networks:
       - laravel
 
   mysql:
-    image: mariadb:10.6
+    image: mariadb:11.4
     container_name: ${APP_NAME}_mysql
     restart: unless-stopped
     tty: true
@@ -106,7 +104,7 @@ services:
       - laravel
 
   npm:
-    image: node:18.11-alpine
+    image: node:22-alpine
     container_name: ${APP_NAME}_npm
     volumes:
       - ./src:/var/www/html
@@ -135,9 +133,9 @@ services:
     networks:
       - laravel
 
-  mailhog:
-    image: mailhog/mailhog:latest
-    container_name: ${APP_NAME}_mailhog
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: ${APP_NAME}_mailpit
     ports:
       - ${MAILHOG_PORT}:1025
       - ${MAILHOG1_PORT}:8025

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 networks:
   laravel:
 
@@ -24,12 +22,12 @@ services:
       - redis
       - mysql
       - phpmyadmin
-      - mailhog
+      - mailpit
     networks:
       - laravel
 
   mysql:
-    image: mariadb:10.6
+    image: mariadb:11.4
     container_name: ${APP_NAME}_mysql
     restart: unless-stopped
     tty: true
@@ -109,7 +107,7 @@ services:
       - laravel
 
   npm:
-    image: node:18.11-alpine
+    image: node:22-alpine
     container_name: ${APP_NAME}_npm
     volumes:
       - ./src:/var/www/html
@@ -138,9 +136,9 @@ services:
     networks:
       - laravel
 
-  mailhog:
-    image: mailhog/mailhog:latest
-    container_name: ${APP_NAME}_mailhog
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: ${APP_NAME}_mailpit
     ports:
       - ${MAILHOG_PORT}:1025
       - ${MAILHOG1_PORT}:8025


### PR DESCRIPTION
Modernize both docker-compose files:

- **Remove** deprecated `version: '3'` key
- **Replace** MailHog → Mailpit (`axllent/mailpit`) — MailHog is unmaintained
- **Upgrade** MariaDB 10.6 → 11.4 LTS
- **Upgrade** Node 18.11 → 22 LTS

Ports remain the same (1025/8025) for seamless migration.

Co-Authored-By: Oz <oz-agent@warp.dev>